### PR TITLE
Add isqrt feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(isqrt)]
 // TODO:
 // - Specialization for instances with a single part.
 // - Use trace instead of eprintln.


### PR DESCRIPTION
Without this, the code does not compile on my rust stable. It does compile on nightly but that is not available on all clusters.

Note that I know nothing about Rust. This might be the wrong solution.