### PR TITLE
feat: optional 32-bit deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ci:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: x86_64 · default features
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: ""
+            test: true
+          - name: x86_64 · no-default-features
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: --no-default-features
+            test: true
+          - name: x86_64 · elias-fano only
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: --no-default-features --features elias-fano
+            test: true
+          - name: x86_64 · gxhash only
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: --no-default-features --features gxhash
+            test: true
+          - name: x86_64 · all stable features
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: --no-default-features --features elias-fano,gxhash,epserde,hashers
+            test: true
+          - name: aarch64 · default features
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: ""
+            test: true
+          - name: aarch64 · no-default-features
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            rustflags: -C target-cpu=native
+            features: --no-default-features
+            test: true
+          # 32-bit platform cross compilation.
+          # `sucds` is 64-bit only and `gxhash` needs AES so it can't build.
+          # We clear RUSTFLAGS to override the cargo config.toml target-cpu flag
+            # because it'll resolve to x86_64 on this runner (there are no 32-bit
+          # gitub runners). We run `cargo build` and not `check`, so to catch
+          # 32-bit overflows.
+          - name: i686 · no-default-features (cross)
+            runner: ubuntu-latest
+            target: i686-unknown-linux-gnu
+            rustflags: ""
+            features: --no-default-features
+            test: false
+          - name: armv7 · no-default-features (cross)
+            runner: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            rustflags: ""
+            features: --no-default-features
+            test: false
+    env:
+      RUSTFLAGS: ${{ matrix.rustflags }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          key: ${{ matrix.name }}
+      - name: Build library
+        run: cargo build --lib ${{ matrix.features }} --target ${{ matrix.target }}
+      - name: Test (lib + doctests)
+        if: ${{ matrix.test }}
+        run: |
+          cargo test --lib ${{ matrix.features }} --target ${{ matrix.target }}
+          cargo test --doc ${{ matrix.features }} --target ${{ matrix.target }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,86 +10,58 @@ env:
 
 jobs:
   ci:
-    name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    name: ${{ matrix.arch.name }} · ${{ matrix.features.name }}
+    runs-on: ${{ matrix.arch.runner }}
     strategy:
       fail-fast: false
       matrix:
+        arch:
+          - name: x86_64
+            runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - name: aarch64
+            runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+        features:
+          - name: no-default-features
+            flags: --no-default-features
+          - name: all stable features
+            flags: --no-default-features --features elias-fano,gxhash,epserde,hashers
         include:
-          - name: x86_64 · default features
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: ""
-            test: true
-          - name: x86_64 · no-default-features
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: --no-default-features
-            test: true
-          - name: x86_64 · elias-fano only
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: --no-default-features --features elias-fano
-            test: true
-          - name: x86_64 · gxhash only
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: --no-default-features --features gxhash
-            test: true
-          - name: x86_64 · all stable features
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: --no-default-features --features elias-fano,gxhash,epserde,hashers
-            test: true
-          - name: aarch64 · default features
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: ""
-            test: true
-          - name: aarch64 · no-default-features
-            runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            rustflags: -C target-cpu=native
-            features: --no-default-features
-            test: true
           # 32-bit platform cross compilation.
-          # `sucds` is 64-bit only and `gxhash` needs AES so it can't build.
-          # We clear RUSTFLAGS to override the cargo config.toml target-cpu flag
-            # because it'll resolve to x86_64 on this runner (there are no 32-bit
-          # gitub runners). We run `cargo build` and not `check`, so to catch
-          # 32-bit overflows.
-          - name: i686 · no-default-features (cross)
-            runner: ubuntu-latest
-            target: i686-unknown-linux-gnu
-            rustflags: ""
-            features: --no-default-features
-            test: false
-          - name: armv7 · no-default-features (cross)
-            runner: ubuntu-latest
-            target: armv7-unknown-linux-gnueabihf
-            rustflags: ""
-            features: --no-default-features
-            test: false
+          # `sucds` is 64-bit only and `gxhash` needs AES so they can't build.
+          # We clear RUSTFLAGS via `cross` to override the `target-cpu=native` from cargo's config.toml,
+          # which would resolve to x86_64 on this runner (there are no 32-bit GitHub
+          # runners). We `build` rather than `check` to catch 32-bit overflows,
+          # and skip tests since we can't run them.
+          - arch:
+              name: i686 (cross)
+              runner: ubuntu-latest
+              target: i686-unknown-linux-gnu
+            features:
+              name: no-default-features
+              flags: --no-default-features
+            cross: true
+          - arch:
+              name: armv7 (cross)
+              runner: ubuntu-latest
+              target: armv7-unknown-linux-gnueabihf
+            features:
+              name: no-default-features
+              flags: --no-default-features
+            cross: true
     env:
-      RUSTFLAGS: ${{ matrix.rustflags }}
+      RUSTFLAGS: ${{ matrix.cross && '' || '-C target-cpu=native' }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: ${{ matrix.target }}
+          targets: ${{ matrix.arch.target }}
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          key: ${{ matrix.name }}
+          key: ${{ matrix.arch.name }} ${{ matrix.features.name }}
       - name: Build library
-        run: cargo build --lib ${{ matrix.features }} --target ${{ matrix.target }}
+        run: cargo build --lib ${{ matrix.features.flags }} --target ${{ matrix.arch.target }}
       - name: Test (lib + doctests)
-        if: ${{ matrix.test }}
-        run: |
-          cargo test --lib ${{ matrix.features }} --target ${{ matrix.target }}
-          cargo test --doc ${{ matrix.features }} --target ${{ matrix.target }}
+        if: ${{ !matrix.cross }}
+        run: cargo test ${{ matrix.features.flags }} --target ${{ matrix.arch.target }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rand_chacha = "0.9.0"
 rayon = "1.8.0"
 rdst = "0.20.11"
 rustc-hash = "2.1.1"
-sucds = "0.8.0"
+sucds = { version = "0.8.0", optional = true }
 tempfile = "3.8.1"
 fastrand = "2.0.1"
 serde = { version = "1.0.215", features = ["derive"] }
@@ -57,12 +57,15 @@ murmur2 = {version="0.1.0", optional=true}
 murmur3 =  {version="0.5.2", optional=true}
 wyhash =  {version="0.5.0", optional=true}
 log = "0.4.27"
-gxhash = "3.5.0"
+gxhash = { version = "3.5.0", optional = true }
 
 [features]
+default = ["elias-fano", "gxhash"]
 epserde = ["dep:epserde", "dep:epserde-derive", "cacheline-ef/epserde"]
 # Enable iter_array_chunks unstable feature for iter_batch_exact, which is only for benchmarking.
 unstable = []
+elias-fano = ["dep:sucds"]
+gxhash = ["dep:gxhash"]
 # Allow additional hash functions, on top of just FxHash and XxHash.
 hashers = ["dep:cityhash-102-rs", "dep:fastmurmur3", "dep:hashers", "dep:highway", "dep:metrohash", "dep:murmur2", "dep:murmur3", "dep:wyhash"]
 # default = ["epserde"]
@@ -74,3 +77,11 @@ serde_json = "1.0.133"
 [[example]]
 name = "epserde"
 required-features = ["epserde"]
+
+[[example]]
+name = "string_keys"
+required-features = ["elias-fano", "gxhash"]
+
+[[example]]
+name = "evals"
+required-features = ["elias-fano", "gxhash"]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -28,6 +28,7 @@
 //! call specialized functions rather than going through the generic `Hasher`
 //! interface.
 //!
+#[cfg(feature = "gxhash")]
 use gxhash::GxBuildHasher;
 
 use crate::KeyT;
@@ -93,11 +94,14 @@ pub type FxHash = fxhash::FxHasher64;
 ///
 /// Prefer [`Xxh3Int`] for integers, which avoids some overhead of the default hasher.
 pub type Xxh3 = xxhash_rust::xxh3::Xxh3Default;
+#[cfg(feature = "gxhash")]
 pub type Gx = gxhash::GxHasher;
 
 /// Use gxhash for 64-bit string hashing.
+#[cfg(feature = "gxhash")]
 pub type StringHash = Gx;
 /// Use gxhash for 128-bit string hashing.
+#[cfg(feature = "gxhash")]
 pub type StringHash128 = Gx128;
 
 // Implementations
@@ -117,9 +121,11 @@ impl<Key: KeyT + ?Sized> KeyHasher<Key> for Xxh3_128 {
 }
 
 /// 128-bit version of XXH3.
+#[cfg(feature = "gxhash")]
 #[cfg_attr(feature = "epserde", derive(epserde::prelude::Epserde))]
 #[derive(Clone)]
 pub struct Gx128;
+#[cfg(feature = "gxhash")]
 impl<Key: KeyT + ?Sized> KeyHasher<Key> for Gx128 {
     type H = u128;
     #[inline(always)]
@@ -156,6 +162,7 @@ pub struct NoHash;
 pub struct Xxh3Int;
 
 /// Inlined version of Xxh3 for integer keys.
+#[cfg(feature = "gxhash")]
 #[cfg_attr(feature = "epserde", derive(epserde::prelude::Epserde))]
 #[derive(Clone)]
 pub struct GxInt;
@@ -191,6 +198,7 @@ macro_rules! int_hashers {
                 }
             }
 
+            #[cfg(feature = "gxhash")]
             impl KeyHasher<$t> for GxInt {
                 type H = u64;
                 #[inline(always)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,12 +75,14 @@
 //!
 //! ```
 //! // Hashing strings
+//! # #[cfg(feature = "gxhash")] {
 //! use ptr_hash::{DefaultPtrHash, PtrHashParams, hash::StringHash};
 //!
 //! let keys = vec!["abc", "def"];
 //! let mphf = <DefaultPtrHash<StringHash, _, _>>::new(&keys, PtrHashParams::default());
 //!
 //! let idx = mphf.index(&"def");
+//! # }
 //! ```
 //!
 //! ## Partitioning
@@ -120,11 +122,13 @@
 //! [`PtrHashParams::default_compact()`] is even smaller, but even slower to construct, and generally less reliable.
 //!
 //! ```
+//! # #[cfg(feature = "elias-fano")] {
 //! use ptr_hash::{PtrHash, PtrHashParams};
 //!
 //! let params = PtrHashParams::default_balanced();
 //! let keys = vec![1u64, 2, 3];
 //! let mphf = <PtrHash<_, _, ptr_hash::pack::EliasFano>>::new(&keys, params);
+//! # }
 //! ```
 
 /// Customizable Hasher trait.

--- a/src/pack.rs
+++ b/src/pack.rs
@@ -4,6 +4,7 @@
 //! This is implemented for `Vec<u8|u16|u32|u64>`, `CachelineEfVec`, and `EliasFano` from `sucds`.
 //! `Packed` is also implemented for respective non-owning (slice) types to support epserde.
 
+#[cfg(feature = "elias-fano")]
 use sucds::mii_sequences::EliasFanoBuilder;
 
 use cacheline_ef::{CachelineEf, CachelineEfVec};
@@ -110,8 +111,10 @@ impl<T: AsRef<[CachelineEf]> + Sync> Packed for CachelineEfVec<T> {
 }
 
 /// Wrapper around the Sucds implementation.
+#[cfg(feature = "elias-fano")]
 pub struct EliasFano(sucds::mii_sequences::EliasFano);
 
+#[cfg(feature = "elias-fano")]
 impl MutPacked for EliasFano {
     fn default() -> Self {
         EliasFano(Default::default())
@@ -132,6 +135,7 @@ impl MutPacked for EliasFano {
     }
 }
 
+#[cfg(feature = "elias-fano")]
 impl Packed for EliasFano {
     fn index(&self, index: usize) -> u64 {
         self.0.select(index as _).unwrap() as u64

--- a/src/shard.rs
+++ b/src/shard.rs
@@ -28,12 +28,16 @@ pub enum Sharding {
 
 impl clap::ValueEnum for Sharding {
     fn value_variants<'a>() -> &'a [Self] {
-        // 128 GiB for Hybrid.
+        // 128 GiB for Hybrid & usize::MAX for 32-bit systems.
+        #[cfg(target_pointer_width = "64")]
+        const HYBRID_BYTES: usize = 1 << 37;
+        #[cfg(not(target_pointer_width = "64"))]
+        const HYBRID_BYTES: usize = usize::MAX;
         &[
             Sharding::None,
             Sharding::Memory,
             Sharding::Disk,
-            Sharding::Hybrid(1 << 37),
+            Sharding::Hybrid(HYBRID_BYTES),
         ]
     }
     fn to_possible_value<'a>(&self) -> Option<PossibleValue> {

--- a/src/test.rs
+++ b/src/test.rs
@@ -59,11 +59,14 @@ fn int_hash_speed() {
     }
     eprintln!("Time {:?}", start.elapsed());
 
-    let start = std::time::Instant::now();
-    for k in &keys {
-        black_box(GxInt::hash(k, seed));
+    #[cfg(feature = "gxhash")]
+    {
+        let start = std::time::Instant::now();
+        for k in &keys {
+            black_box(GxInt::hash(k, seed));
+        }
+        eprintln!("Time {:?}", start.elapsed());
     }
-    eprintln!("Time {:?}", start.elapsed());
 
     let start = std::time::Instant::now();
     for k in &keys {
@@ -263,6 +266,7 @@ fn integer_key_types() {
 }
 
 #[test]
+#[cfg(feature = "gxhash")]
 fn string_key_types() {
     let h = DefaultPtrHash::<StringHash, &str>::new(&["a"], PtrHashParams::default());
 


### PR DESCRIPTION
Hello!

For https://github.com/huggingface/tokenizers we need to support a wide breadth of platforms, including 32-bit variants. We started using your PtrHash lib in an ongoing refactor, because we need speed 😄, so naturally when I saw that our CI was red because of a part of the lib we don't use, I thought you might be open to gate these with feature flags.

I have a question when it comes to `Sharding::Hybrid` which currently holds a `usize`. This in practice causes no problem, but as you set its value to `1 << 37` or 128gb, it'll overflow on 32-bit platforms. I added a `cfg` clause and set the value to `usize::MAX` when on 32-bit. I was hesitating to change the type of `Sharding::Hybrid` to `u64`, but since it's public API I'd rather have your opinion on this before changing (also implies a few castings here and there in the `shard_keys_hybrid` fn).

Finally, I added CI in the spirit of the one we have on tokenizers, but you might not want it -- I can remove it if not.

Lmk if there's any interest in merging this, we'd be adopting your library if so!