### PR TITLE
feat: remove unused deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,12 +648,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,7 +913,6 @@ dependencies = [
 name = "ptr_hash"
 version = "2.0.0-alpha.1"
 dependencies = [
- "anyhow",
  "bitvec",
  "cacheline-ef",
  "cityhash-102-rs",
@@ -935,7 +928,6 @@ dependencies = [
  "hashers",
  "highway",
  "itertools 0.14.0",
- "lazy_static",
  "log",
  "mem_dbg 0.4.2",
  "metrohash",
@@ -945,7 +937,6 @@ dependencies = [
  "rand_chacha",
  "rayon",
  "rdst",
- "rustc-hash",
  "serde",
  "serde_json",
  "sucds",
@@ -1073,12 +1064,6 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
-
-[[package]]
-name = "rustc-hash"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,19 +22,16 @@ lto = "thin"
 incremental = true
 
 [dependencies]
-anyhow = "1.0.75"
 bitvec = "1.0.1"
 clap = { version = "4.4.6", features = ["derive"] }
 colored = "3.0.0"
 epserde = { version = "0.8.0", optional = true }
 epserde-derive = {version = "0.8.0", optional = true }
 itertools = "0.14.0"
-lazy_static = "1.4.0"
 rand = "0.9.0"
 rand_chacha = "0.9.0"
 rayon = "1.8.0"
 rdst = "0.20.11"
-rustc-hash = "2.1.1"
 sucds = { version = "0.8.0", optional = true }
 tempfile = "3.8.1"
 fastrand = "2.0.1"


### PR DESCRIPTION
While looking around the crate, I noticed `anyhow`, `lazy_static` and `rustc-hash` were unused.

Would it be possible to remove them?